### PR TITLE
feat: add recursive directory scanning and flexible CLI usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build directories
+build/
+cmake-build-*/
+
+# Executables
+*.exe
+*.dll
+
+# IDE/Editor settings
+.vscode/
+.idea/
+*.swp
+
+# OS generated files
+thumbs.db
+Desktop.ini
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,8 @@ add_executable(jxr_to_avif main.c)
 find_library(AVIF_LIBRARY avif PATHS ${PROJECT_SOURCE_DIR}/lib REQUIRED NO_DEFAULT_PATH)
 find_library(AOM_LIBRARY aom PATHS ${PROJECT_SOURCE_DIR}/lib REQUIRED NO_DEFAULT_PATH)
 
-target_link_libraries(jxr_to_avif ${AVIF_LIBRARY} ${AOM_LIBRARY} "$<$<CONFIG:Release>:-s -static>")
+target_link_libraries(jxr_to_avif ${AVIF_LIBRARY} ${AOM_LIBRARY} windowscodecs ole32 oleaut32 uuid)
+
+if(MINGW)
+    target_link_options(jxr_to_avif PRIVATE -static)
+endif()


### PR DESCRIPTION
- Implements recursive folder scanning for default and folder-argument modes.
- Adds flexible argument parsing (e.g. jxr_to_avif input.jxr [output.avif]).
- Updates CMakeLists.txt for MinGW compatibility and proper linking.
- Fixes compatibility issues with MinGW (removed _Float16, VLA, fixed format strings).
- Fixes double-free bug in conversion loop.
- Adds .gitignore for build artifacts.
- Now you can use the exe without any argument to convert all jxr files within the same folder as the exe to avif files.
- Now you can use the exe without any argument to convert all jxr files within all folders within the same folder as the exe to avif files.
- Now you can use the original command to convert a specific jxr file or jxr files within a specific folder to avif files.